### PR TITLE
Refine OCR pipeline with Swift concurrency

### DIFF
--- a/SnapText/FloatingTextEditingCanvas.swift
+++ b/SnapText/FloatingTextEditingCanvas.swift
@@ -405,7 +405,7 @@ private struct FloatingTextViewRepresentable: UIViewRepresentable {
                 }
                 .filter { !$0.isNull && !$0.isInfinite && !$0.isEmpty }
 
-            DispatchQueue.main.async {
+            Task { @MainActor in
                 self.parent.selectionRects = rects
             }
         }

--- a/SnapText/OCRService.swift
+++ b/SnapText/OCRService.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Vision
+import UIKit
+
+enum OCRServiceError: Error {
+    case invalidImage
+}
+
+struct OCRService {
+    static func recognizeText(in image: UIImage) async throws -> String {
+        guard let cgImage = image.cgImage else {
+            throw OCRServiceError.invalidImage
+        }
+
+        return try await Task.detached(priority: .userInitiated) {
+            let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+            let request = VNRecognizeTextRequest()
+            request.recognitionLevel = .accurate
+            request.usesLanguageCorrection = true
+            if #available(iOS 16.0, *) {
+                request.revision = VNRecognizeTextRequestRevision3
+            }
+
+            try handler.perform([request])
+
+            let observations = (request.results as? [VNRecognizedTextObservation]) ?? []
+            return observations
+                .compactMap { $0.topCandidates(1).first?.string }
+                .joined(separator: "\n")
+        }.value
+    }
+}


### PR DESCRIPTION
## Summary
- add an OCRService that performs Vision recognition with async/await
- update ContentView to await table detection and OCR results while updating UI on the main actor
- switch the floating text canvas selection updates to use Task and MainActor instead of DispatchQueue

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69163ba6f7f4832aacf55bb1346a6a73)