### PR TITLE
Add telemetry README and remove editor suggestions / duplicate title

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,17 @@ It allows users to capture, edit, and export documents into professional formats
   - Editable **.xlsx** (Excel)  
   - **.pdf** or **.txt**  
 
+
+## 📡 Telemetry
+
+SnapText includes a privacy-aware telemetry pipeline for reliability and product diagnostics.
+
+- Event queueing + local persistence
+- Session hashing + metadata minimization
+- KPI snapshots and debug export tools
+
+See `SnapText/Telemetry/README.md` for implementation details.
+
 ---
 
 ## 📸 Screenshots

--- a/SnapText/Telemetry/README.md
+++ b/SnapText/Telemetry/README.md
@@ -1,0 +1,37 @@
+# Telemetry in SnapText
+
+This module implements on-device telemetry collection for product diagnostics and KPI tracking.
+
+## What it tracks
+
+Events are modeled in `TelemetryEventName` and include:
+- capture/parsing lifecycle (`image_selected`, `parse_started`, `parse_succeeded`, `parse_failed`)
+- export lifecycle (`export_started`, `export_succeeded`, `export_failed`)
+- table flow (`table_detected`, `table_detection_failed`)
+- UX/product signals (`camera_opened`, `parse_mode_switched`, `document_saved`, etc.)
+
+## Privacy model
+
+- Each event has a `PrivacyClassification` (`anonymous_metadata_only` or `sensitive_content_never_collect`).
+- Session identity is a salted hash from a local UUID via `TelemetrySessionManager` (no raw user identifier is stored).
+- Metadata is capped and lightly noised (`noise`) to reduce exact fingerprinting while keeping trends useful.
+
+## Architecture
+
+- `TelemetryManager` is the app-facing singleton API (`track`, `clear`, `snapshotKPI`, `exportURL`).
+- `TelemetryQueue` is an actor-backed queue with bounded size and batch draining.
+- `TelemetryStorage` persists queued events into `telemetry_queue.json` in the app documents directory.
+- `TelemetryUploader` performs best-effort uploads (stub endpoint in this project).
+- `TelemetryAnalytics` computes local KPI rollups for debug/UI use.
+
+## Operational behavior
+
+- Tracking is opt-in controlled by `telemetryEnabled`.
+- Uploading is best-effort and resilient: failed uploads keep events queued.
+- A telemetry debug screen (`TelemetryDebugView`) exposes queue state, failures, KPI snapshot, clear, and JSON export.
+
+## Key files
+
+- `SnapText/Telemetry/TelemetryCore.swift`
+- `SnapText/Views/Telemetry/TelemetryDebugView.swift`
+- `SnapTextTests/Telemetry/TelemetryTests.swift`

--- a/SnapText/Views/Components/FloatingTextEditingCanvas.swift
+++ b/SnapText/Views/Components/FloatingTextEditingCanvas.swift
@@ -34,98 +34,13 @@ struct FloatingTextEditingCanvas: View {
             }
             .frame(minHeight: 260, maxHeight: .infinity)
 
-            suggestionBar
         }
     }
 
 
 
 
-    @ViewBuilder
-    private var suggestionBar: some View {
-        let suggestions = suggestionCandidates()
-        if !suggestions.isEmpty {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 12) {
-                    ForEach(suggestions, id: \.self) { suggestion in
-                        Button(action: {
-                            applySuggestion(suggestion)
-                        }) {
-                            Text(suggestion)
-                                .font(.system(size: 15, weight: .medium))
-                                .padding(.horizontal, 14)
-                                .padding(.vertical, 8)
-                                .background(Color.white.opacity(0.12))
-                                .clipShape(Capsule())
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-                .padding(.horizontal, 12)
-            }
-            .frame(height: 44)
-        }
-    }
-
-    private func suggestionCandidates() -> [String] {
-        let words = text.split(whereSeparator: { !$0.isLetter })
-        guard let last = words.last else { return ["Check", "Correct", "Clean"] }
-        let base = String(last)
-        var ordered: [String] = []
-        func appendUnique(_ candidate: String) {
-            if !ordered.contains(candidate) {
-                ordered.append(candidate)
-            }
-        }
-        if base.count > 3 {
-            appendUnique(base.capitalized)
-            appendUnique(base.lowercased())
-            appendUnique(base + "?")
-            appendUnique(base + "!")
-        } else {
-            ["Correct", "Review", "Confirm"].forEach(appendUnique)
-        }
-        return Array(ordered.prefix(5))
-    }
-
-    private func applySuggestion(_ suggestion: String) {
-        if let range = rangeOfLastEditableWord(in: text) {
-            let startOffset = range.lowerBound.utf16Offset(in: text)
-            text.replaceSubrange(range, with: suggestion)
-            selectedRange = NSRange(location: startOffset + suggestion.count, length: 0)
-        } else {
-            text = suggestion
-            selectedRange = NSRange(location: suggestion.count, length: 0)
-        }
-    }
-
-
-    private func rangeOfLastEditableWord(in value: String) -> Range<String.Index>? {
-        var end = value.endIndex
-        while end > value.startIndex {
-            let previous = value.index(before: end)
-            if value[previous].isWhitespace || value[previous].isNewline {
-                end = previous
-                continue
-            }
-            var cursor = previous
-            var start = previous
-            while cursor > value.startIndex {
-                let before = value.index(before: cursor)
-                if value[before].isWhitespace || value[before].isNewline {
-                    break
-                }
-                cursor = before
-                start = before
-            }
-            let rangeEnd = value.index(after: previous)
-            return start..<rangeEnd
-        }
-        return nil
-    }
-
-
-}
+    
 
 // MARK: - Selection Overlay
 

--- a/SnapText/Views/EditableDocView.swift
+++ b/SnapText/Views/EditableDocView.swift
@@ -49,7 +49,7 @@ struct EditableDocView: View {
             .foregroundColor(.yellow)
         }
         // Use nav bar for the title so Back shows “Docs Gallery”
-        .navigationTitle(doc.title.isEmpty ? "Untitled" : doc.title)
+         .navigationTitle("Document")
         .navigationBarTitleDisplayMode(.inline)
         .background(Color.black.edgesIgnoringSafeArea(.all))
         .preferredColorScheme(.dark)


### PR DESCRIPTION
### Motivation

- Provide explicit documentation for the app's telemetry implementation so engineers and reviewers can understand what is collected, how privacy is preserved, and how the pipeline operates.
- Remove the end-of-text suggestion chips that were producing unwanted suggestion words at the end of the editor UI. 
- Prevent the duplicate "Untitled" presentation by keeping the inline editable title and using a single, stable navigation title.

### Description

- Added `SnapText/Telemetry/README.md` documenting tracked events, privacy model, architecture, and operational behavior. 
- Updated the root `README.md` to include a new Telemetry section linking to the telemetry documentation. 
- Removed the suggestion bar and all suggestion-candidate logic from `SnapText/Views/Components/FloatingTextEditingCanvas.swift`. 
- Replaced the dynamic navigation title in `SnapText/Views/EditableDocView.swift` with a stable `"Document"` title to avoid duplication with the inline editable title field.

### Testing

- Attempted to run Xcode project checks with `xcodebuild -list` but the command failed in this environment (`xcodebuild: command not found`).
- No unit/integration tests were executed here; telemetry unit tests exist at `SnapTextTests/Telemetry/TelemetryTests.swift` but were not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f63876734832aa48fa94bbacc5ad6)